### PR TITLE
Add 'add_comment' tool and 'with_block_ids' param to 'get_page'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,25 @@
 {
   "name": "@larryhudson/simple-notion-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larryhudson/simple-notion-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.2",
         "@notionhq/client": "^2.3.0",
         "dotenv": "^16.5.0",
+        "marked": "^15.0.11",
         "p-map": "^7.0.3"
       },
       "bin": {
         "simple-notion-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/marked": "^5.0.2"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -51,6 +55,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@types/marked": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.2.tgz",
+      "integrity": "sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.15.2",
@@ -662,6 +673,18 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.11.tgz",
+      "integrity": "sha512-1BEXAU2euRCG3xwgLVT1y0xbJEld1XOrmRJpUwRCcy7rxhSCwMrmEu9LXoPhHSCJG41V7YcQ2mjKRr5BA3ITIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "@modelcontextprotocol/sdk": "^1.10.2",
     "@notionhq/client": "^2.3.0",
     "dotenv": "^16.5.0",
+    "marked": "^15.0.11",
     "p-map": "^7.0.3"
+  },
+  "devDependencies": {
+    "@types/marked": "^5.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { handler as handleGetPage } from "./tools/getPage.js"
+import { handler as handleAddComment } from "./tools/addComment.js"
 
 const server = new McpServer({
   name: "Simple Notion MCP server",
@@ -11,15 +12,35 @@ const server = new McpServer({
 });
 
 server.tool("get_page",
-    "Get a Notion page by ID, rendered as Markdown",
-  { page_id: z.string() },
-  async ({ page_id }) => {
+    "Get a Notion page by ID, rendered as Markdown. Set with_block_ids to true if you want to add comments to specific blocks later.",
+  { 
+    page_id: z.string(),
+    with_block_ids: z.boolean().optional().default(false)
+  },
+  async ({ page_id, with_block_ids }) => {
     // TODO: consider making handleGetPage return the whole tool response object
-    const markdown = await handleGetPage(page_id);
+    const markdown = await handleGetPage(page_id, with_block_ids);
     return {
       content: [{
         type: "text",
         text: markdown
+      }]
+    }
+  }
+);
+
+server.tool("add_comment",
+    "Add a comment to a specific block in a Notion page. The block_id can be obtained from get_page with with_block_ids=true.",
+  { 
+    block_id: z.string(),
+    comment_content: z.string()
+  },
+  async ({ block_id, comment_content }) => {
+    const result = await handleAddComment(block_id, comment_content);
+    return {
+      content: [{
+        type: "text",
+        text: result
       }]
     }
   }

--- a/src/lib/markdownToRichText.ts
+++ b/src/lib/markdownToRichText.ts
@@ -1,0 +1,117 @@
+import { marked } from 'marked';
+import type { Tokens } from 'marked';
+
+// Define the types based on Notion API documentation
+interface NotionRichText {
+  type: 'text';
+  text: {
+    content: string;
+    link?: { url: string };
+  };
+  annotations?: {
+    bold?: boolean;
+    italic?: boolean;
+    strikethrough?: boolean;
+    underline?: boolean;
+    code?: boolean;
+    color?: string;
+  };
+}
+
+/**
+ * Converts Markdown text to Notion's rich text format.
+ * This function handles basic Markdown formatting: bold, italic, links, code.
+ * 
+ * @param markdownContent The markdown content to convert
+ * @returns An array of rich text objects for Notion API
+ */
+export function markdownToRichText(markdownContent: string): any[] {
+  if (!markdownContent || !markdownContent.trim()) {
+    return [];
+  }
+
+  // Initialize rich text items array
+  const richTextItems: NotionRichText[] = [];
+
+  // Use a custom renderer to convert markdown to rich text objects
+  const renderer = new marked.Renderer();
+
+  // Track active annotations during parsing
+  const activeAnnotations = {
+    bold: false,
+    italic: false,
+    code: false,
+    strikethrough: false,
+  };
+
+  // Create a simple segment of text with current annotations
+  const createSegment = (text: string, override: Partial<typeof activeAnnotations> = {}, link?: string) => {
+    if (!text) return;
+
+    const annotations: NotionRichText['annotations'] = {};
+    
+    if (activeAnnotations.bold || override.bold) annotations.bold = true;
+    if (activeAnnotations.italic || override.italic) annotations.italic = true;
+    if (activeAnnotations.code || override.code) annotations.code = true;
+    if (activeAnnotations.strikethrough || override.strikethrough) annotations.strikethrough = true;
+
+    const textObj: NotionRichText = {
+      type: 'text',
+      text: { content: text }
+    };
+
+    if (link) {
+      textObj.text.link = { url: link };
+    }
+
+    if (Object.keys(annotations).length > 0) {
+      textObj.annotations = annotations;
+    }
+
+    richTextItems.push(textObj);
+  };
+
+  // Override necessary renderer functions
+  renderer.strong = (token: Tokens.Strong) => {
+    activeAnnotations.bold = true;
+    createSegment(token.text);
+    activeAnnotations.bold = false;
+    return '';
+  };
+
+  renderer.em = (token: Tokens.Em) => {
+    activeAnnotations.italic = true;
+    createSegment(token.text);
+    activeAnnotations.italic = false;
+    return '';
+  };
+
+  renderer.codespan = (token: Tokens.Codespan) => {
+    activeAnnotations.code = true;
+    createSegment(token.text);
+    activeAnnotations.code = false;
+    return '';
+  };
+
+  renderer.del = (token: Tokens.Del) => {
+    activeAnnotations.strikethrough = true;
+    createSegment(token.text);
+    activeAnnotations.strikethrough = false;
+    return '';
+  };
+
+  renderer.link = (token: Tokens.Link) => {
+    createSegment(token.text, {}, token.href);
+    return '';
+  };
+
+  renderer.text = (token: Tokens.Text) => {
+    createSegment(token.text);
+    return '';
+  };
+
+  // Parse markdown with custom renderer
+  marked(markdownContent, { renderer });
+
+  return richTextItems;
+}

--- a/src/lib/notionApi.ts
+++ b/src/lib/notionApi.ts
@@ -77,3 +77,40 @@ export const fetchPage = async (
         throw error;
     }
 }
+
+import { markdownToRichText } from './markdownToRichText.js';
+
+export const addComment = async (
+    blockId: string,
+    commentContent: string
+): Promise<any> => {
+    try {
+        // Convert markdown content to Notion's rich text format
+        const richTextItems = markdownToRichText(commentContent);
+        
+        // If no rich text items were created (possibly empty content),
+        // fall back to simple text content
+        const richText = richTextItems.length > 0 ? richTextItems : [
+            {
+                type: 'text',
+                text: {
+                    content: commentContent || '',
+                },
+            },
+        ];
+        
+        // According to Notion API documentation, comments can be created on pages or
+        // as replies to existing comments in discussions
+        const response = await notion.comments.create({
+            parent: {
+                page_id: blockId, // Using the block ID as the page ID
+            },
+            rich_text: richText,
+        });
+        
+        return response;
+    } catch (error) {
+        console.error(`Error adding comment to block ${blockId}:`, error);
+        throw error;
+    }
+}

--- a/src/tools/addComment.ts
+++ b/src/tools/addComment.ts
@@ -1,0 +1,30 @@
+import * as notionApi from "../lib/notionApi.js";
+
+/**
+ * Add a comment to a specific block in a Notion page
+ * @param blockId The ID of the block to add the comment to
+ * @param commentContent The markdown content to add as a comment
+ * @returns A confirmation message with the comment ID
+ */
+export const handler = async (
+    blockId: string,
+    commentContent: string
+): Promise<string> => {
+    try {
+        // Validate inputs
+        if (!blockId) {
+            throw new Error("Block ID is required");
+        }
+        if (!commentContent) {
+            throw new Error("Comment content is required");
+        }
+
+        // Add comment to the block using the notionApi function
+        const response = await notionApi.addComment(blockId, commentContent);
+
+        return `Comment added successfully with ID: ${response.id}`;
+    } catch (error: any) {
+        console.error(`Error adding comment to block ${blockId}:`, error);
+        throw new Error(`Failed to add comment: ${error.message || "Unknown error"}`);
+    }
+};

--- a/src/tools/getPage.ts
+++ b/src/tools/getPage.ts
@@ -2,7 +2,8 @@ import * as formatter from "../lib/formatter.js";
 import * as notionApi from "../lib/notionApi.js";
 
 export const handler = async (
-    pageId: string
+    pageId: string,
+    with_block_ids: boolean = false
 ): Promise<string> => {
     // Fetch page information to get title and other metadata
     const pageInfo = await notionApi.fetchPage(pageId);
@@ -10,7 +11,7 @@ export const handler = async (
     
     // Fetch blocks for the page content
     const blocks = await notionApi.fetchChildBlocks(pageId);
-    const blocksContent = formatter.renderBlocksAsMarkdown(blocks);
+    const blocksContent = formatter.renderBlocksAsMarkdown(blocks, with_block_ids);
 
     return `${frontmatter}\n\n${blocksContent}`;
 }


### PR DESCRIPTION
Closes #2

This PR adds two major features:

1. Added a `with_block_ids` boolean parameter to the existing `get_page` tool
   - When set to `true`, the tool will include HTML comments with block IDs in the markdown output
   - These block IDs can be used with the new add_comment tool
   - The parameter is optional and defaults to `false` to maintain backward compatibility

2. Added a new `add_comment` tool
   - Allows adding comments to specific blocks in Notion pages
   - Takes a block ID and markdown-formatted comment content as parameters
   - Converts markdown to Notion's rich text format for proper formatting

Additional changes:
- Added the `marked` library for Markdown parsing
- Modified the formatter to support including block IDs in output
- Bumped package version from 0.1.1 to 0.1.2